### PR TITLE
New option to use the test executable's path as working directory

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -95,6 +95,7 @@ unfinished form on my harddrive for more than a year. Finally it slipped out.
     <tr><td><code>-mns name dll_or_exe [dll_or_exe_2]</code></td><td>Create a separate namespace with the given name for the listed dll:s. All modules loaded in those module(s) will be namespaced.</td></tr>
     <tr><td><code>-lcl LineCountLimit</code></td><td>Count number of times a line is executed up to the specified limit</td></tr>
     <tr><td><code>-tec</code></td><td>Passthrough the exitcode of the application inspected</td></tr>
+    <tr><td><code>-twd</code></td><td>Use the application's path as working directory</td></tr>
 </table>
 
 ## License

--- a/Source/CoverageConfiguration.pas
+++ b/Source/CoverageConfiguration.pas
@@ -46,6 +46,7 @@ type
     FXmlMergeGenerics: Boolean;
     FHtmlOutput: Boolean;
     FTestExeExitCode: Boolean;
+    FUseTestExePathAsWorkingDir: Boolean;
     FExcludeSourceMaskLst: TStrings;
     FLoadingFromDProj: Boolean;
     FModuleNameSpaces: TModuleNameSpaceList;
@@ -112,6 +113,7 @@ type
     function XmlMergeGenerics: Boolean;
     function HtmlOutput: Boolean;
     function TestExeExitCode: Boolean;
+    function UseTestExePathAsWorkingDir: Boolean;
     function LineCountLimit: Integer;
 
     function ModuleNameSpace(const AModuleName: string): TModuleNameSpace;
@@ -362,6 +364,11 @@ begin
   Result := FTestExeExitCode;
 end;
 
+function TCoverageConfiguration.UseTestExePathAsWorkingDir: Boolean;
+begin
+  Result := FUseTestExePathAsWorkingDir;
+end;
+
 function TCoverageConfiguration.IsPathInExclusionList(const APath: TFileName): Boolean;
 var
   Mask: string;
@@ -396,6 +403,7 @@ begin
   FHtmlOutput := IsSet(I_CoverageConfiguration.cPARAMETER_HTML_OUTPUT);
   uConsoleOutput.G_Verbose_Output := IsSet(I_CoverageConfiguration.cPARAMETER_VERBOSE);
   FTestExeExitCode := IsSet(I_CoverageConfiguration.cPARAMETER_TESTEXE_EXIT_CODE);
+  FUseTestExePathAsWorkingDir := IsSet(I_CoverageConfiguration.cPARAMETER_USE_TESTEXE_WORKING_DIR);
 end;
 
 procedure TCoverageConfiguration.ExcludeSourcePaths;
@@ -572,7 +580,8 @@ begin
   or (SwitchItem = I_CoverageConfiguration.cPARAMETER_XML_LINES_MERGE_GENERICS)
   or (SwitchItem = I_CoverageConfiguration.cPARAMETER_HTML_OUTPUT)
   or (SwitchItem = I_CoverageConfiguration.cPARAMETER_VERBOSE)
-  or (SwitchItem = I_CoverageConfiguration.cPARAMETER_TESTEXE_EXIT_CODE) then
+  or (SwitchItem = I_CoverageConfiguration.cPARAMETER_TESTEXE_EXIT_CODE)
+  or (SwitchItem = I_CoverageConfiguration.cPARAMETER_USE_TESTEXE_WORKING_DIR) then
   begin
     // do nothing, because its already parsed
   end

--- a/Source/Debugger.pas
+++ b/Source/Debugger.pas
@@ -266,7 +266,7 @@ begin
   ConsoleOutput(I_CoverageConfiguration.cPARAMETER_LINE_COUNT +
     ' [number]       -- Count number of times a line is executed up to the specified limit (default 0 - disabled)');
   ConsoleOutput(I_CoverageConfiguration.cPARAMETER_TESTEXE_EXIT_CODE +
-    ' [number]       -- Passthrough the exitcode of the application');
+    '                -- Passthrough the exitcode of the application');
   ConsoleOutput(I_CoverageConfiguration.cPARAMETER_USE_TESTEXE_WORKING_DIR +
     '                -- Use the application''s path as working directory');
 

--- a/Source/Debugger.pas
+++ b/Source/Debugger.pas
@@ -267,6 +267,8 @@ begin
     ' [number]       -- Count number of times a line is executed up to the specified limit (default 0 - disabled)');
   ConsoleOutput(I_CoverageConfiguration.cPARAMETER_TESTEXE_EXIT_CODE +
     ' [number]       -- Passthrough the exitcode of the application');
+  ConsoleOutput(I_CoverageConfiguration.cPARAMETER_USE_TESTEXE_WORKING_DIR +
+    '                -- Use the application''s path as working directory');
 
 end;
 
@@ -387,6 +389,7 @@ var
   StartInfo: TStartupInfo;
   ProcInfo: TProcessInformation;
   Parameters: string;
+  WorkingDir: PChar;
 begin
   Parameters := FCoverageConfiguration.ApplicationParameters;
   FLogManager.Log(
@@ -402,6 +405,12 @@ begin
   StartInfo.hStdOutput := GetStdHandle(STD_OUTPUT_HANDLE);
   StartInfo.hStdError := GetStdHandle(STD_ERROR_HANDLE);
 
+  WorkingDir := nil;
+  if FCoverageConfiguration.UseTestExePathAsWorkingDir then
+  begin
+    WorkingDir := PChar(ExtractFilePath(FCoverageConfiguration.ExeFileName));
+  end;
+
   Parameters := '"' + FCoverageConfiguration.ExeFileName + '" ' + Parameters;
   Result := CreateProcess(
     nil,
@@ -411,7 +420,7 @@ begin
     True,
     CREATE_NEW_PROCESS_GROUP + NORMAL_PRIORITY_CLASS + DEBUG_PROCESS,
     nil,
-    nil,
+    WorkingDir,
     StartInfo,
     ProcInfo
   );

--- a/Source/I_CoverageConfiguration.pas
+++ b/Source/I_CoverageConfiguration.pas
@@ -40,6 +40,7 @@ type
     function XmlMergeGenerics: Boolean;
     function HtmlOutput: Boolean;
     function TestExeExitCode: Boolean;
+    function UseTestExePathAsWorkingDir: Boolean;
     function ModuleNameSpace(const AModuleName: string): TModuleNameSpace;
     function UnitNameSpace(const AModuleName: string): TUnitNameSpace;
     function LineCountLimit: Integer;
@@ -74,6 +75,7 @@ const
   cPARAMETER_UNIT_NAMESPACE = '-uns';
   cPARAMETER_EMMA_SEPARATE_META = '-meta';
   cPARAMETER_TESTEXE_EXIT_CODE = '-tec';
+  cPARAMETER_USE_TESTEXE_WORKING_DIR = '-twd';
   cPARAMETER_LINE_COUNT = '-lcl';
 
   cIGNORE_UNIT_PREFIX = '!';


### PR DESCRIPTION
Hello, 

we have found that some of our unittests load their test-data files by using constant (hard-coded), relative paths.

This works just fine (in regards to the test executable finding its files) when running those tests from within the Delphi IDE, as the working directory is the path of the executable in this case. Also, when the tests are run directly by our Jenkins build server, the current working directory is set explixitely to be the executable's path by our build scripts. So this works fine as well.

When running our tests with Delphi Code Coverage we do not pass the executable (-e) but the project file (-dproj) and in this case we don't know the path of the test executable. So it's a little bit harder to set the required working directory when/before calling the Delphi Code Coverage executable.

Although our unittests could be changed to determine the proper absolute paths by themselves (which we partially did) and this way successfully find their test-data files, we also thought that introducing an additional option '-twd' for Delphi Code Coverage might be a good idea in addition and in general. If this switch is given, Delphi Code Coverage will call `CreateProcess` by passing the test executable's path as working directory. Otherwise `nil` will be passed, like before.

I thought that this might be a reasonable feature and wanted to provide the changes via this pull request.
Please feel free to reject it, or to accept it while fine-tuning or renaming things. I did my best to stick to the current format style and existing names and I hope that I adjusted all places (source code as well as documentation), so that it is complete.

Also, I fixed the description of '-tec' in the usage (probably was a little copy-paste accident).

Thanks and cheers,
Thorsten