### PR TITLE
Update CoverageConfiguration.pas

### DIFF
--- a/Source/CoverageConfiguration.pas
+++ b/Source/CoverageConfiguration.pas
@@ -197,6 +197,8 @@ begin
   FModuleNameSpaces := TModuleNameSpaceList.Create;
   FUnitNameSpaces := TUnitNameSpaceList.Create;
   FLineCountLimit := 0;
+  
+  FOutputDir := ExtractFilePath(ParamStr(0));
 end;
 
 destructor TCoverageConfiguration.Destroy;


### PR DESCRIPTION
Define a default folder if the -od parameter is not filled in and thus avoid a folder creation error.