### PR TITLE
Add class exclusions support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,6 +80,7 @@ unfinished form on my harddrive for more than a year. Finally it slipped out.
     <tr><td><code>-sp directory directory2</code></td><td>The directories where the source can be found</td></tr>
     <tr><td><code>-spf filename</code></td><td>Use source directories listed in the file pointed to by filename. One directory per line in the file</td></tr>
     <tr><td><code>-esm mask1 mask2 etc</code></td><td>A list of file masks to exclude from list of units</td></tr>
+    <tr><td><code>-ecp prefix1 mask2 etc</code></td><td>A list of class prefixes to exclude from coverage</td></tr>
     <tr><td><code>-od directory</code></td><td>The directory where the output files will be put - note - the directory must exist</td></tr>
     <tr><td><code>-u TestUnit TestUnit2</code></td><td>The units that shall be checked for code coverage</td></tr>
     <tr><td><code>-uf filename</code></td><td>Cover units listed in the file pointed to by filename. One unit per line in the file</td></tr>

--- a/Source/ClassInfoUnit.pas
+++ b/Source/ClassInfoUnit.pas
@@ -151,6 +151,9 @@ type
       const AModuleName: string;
       const AModuleFileName: string): TModuleInfo;
 
+    class function GetClassName(const AModuleName: String; const AQualifiedProcName: String): String; overload;
+    class function GetClassName(const AModuleName: String;
+      const AQualifiedProcName: String; var ProcedureName: String): String; overload;
 
     procedure HandleBreakPoint(
       const AModuleName: string;
@@ -283,25 +286,22 @@ begin
   end;
 end;
 
-procedure TModuleList.HandleBreakPoint(
-  const AModuleName: string;
-  const AModuleFileName: string;
-  const AQualifiedProcName: string;
-  const ALineNo: Integer;
-  const ABreakPoint: IBreakPoint;
-  const ALogManager: ILogManager);
+class function TModuleList.GetClassName(const AModuleName: String; const AQualifiedProcName: String): String;
+var
+  ProcedureName: string;
+begin
+  Result := GetClassName(AModuleName, AQualifiedProcName, ProcedureName);
+end;
+
+class function TModuleList.GetClassName(const AModuleName: String;
+  const AQualifiedProcName: String; var ProcedureName: String): String;
 var
   List: TStrings;
   ClassName: string;
-  ProcedureName: string;
-  ClsInfo: TClassInfo;
-  ProcInfo: TProcedureInfo;
-  Module: TModuleInfo;
   ProcedureNameParts: TStringDynArray;
   I: Integer;
   ClassProcName: string;
 begin
-  ALogManager.Log('Adding breakpoint for '+ AQualifiedProcName + ' in ' + AModuleFileName);
   List := TStringList.Create;
   try
     ClassProcName := RightStr(AQualifiedProcName, Length(AQualifiedProcName) - (Length(AModuleName) + 1));
@@ -341,15 +341,35 @@ begin
           ClassName := List[0];
         end;
       end;
-
-      Module := EnsureModuleInfo(AModuleName, AModuleFileName);
-      ClsInfo := Module.EnsureClassInfo(AModuleName, ClassName);
-      ProcInfo := ClsInfo.EnsureProcedure(ProcedureName);
-      ProcInfo.AddBreakPoint(ALineNo, ABreakPoint);
     end;
+
+    Result := ClassName;
   finally
     List.Free;
   end;
+end;
+
+procedure TModuleList.HandleBreakPoint(
+  const AModuleName: string;
+  const AModuleFileName: string;
+  const AQualifiedProcName: string;
+  const ALineNo: Integer;
+  const ABreakPoint: IBreakPoint;
+  const ALogManager: ILogManager);
+var
+  ClassName: string;
+  ProcedureName: string;
+  ClsInfo: TClassInfo;
+  ProcInfo: TProcedureInfo;
+  Module: TModuleInfo;
+begin
+  ALogManager.Log('Adding breakpoint for '+ AQualifiedProcName + ' in ' + AModuleFileName);
+
+  ClassName := GetClassName(AModuleName, AQualifiedProcName, ProcedureName);
+  Module := EnsureModuleInfo(AModuleName, AModuleFileName);
+  ClsInfo := Module.EnsureClassInfo(AModuleName, ClassName);
+  ProcInfo := ClsInfo.EnsureProcedure(ProcedureName);
+  ProcInfo.AddBreakPoint(ALineNo, ABreakPoint);
 end;
 {$endregion 'TModuleList'}
 

--- a/Source/CoverageConfiguration.pas
+++ b/Source/CoverageConfiguration.pas
@@ -35,6 +35,7 @@ type
     FDProjUnitsLst: TStringList;
     FUnitsStrLst: TStringList;
     FExcludedUnitsStrLst: TStringList;
+    FExcludedClassPrefixesStrLst: TStringList;
     FExeParamsStrLst: TStrings;
     FSourcePathLst: TStrings;
     FStripFileExtension: Boolean;
@@ -79,6 +80,8 @@ type
     procedure ParseMapFileSwitch(var AParameter: Integer);
     procedure ParseUnitSwitch(var AParameter: Integer);
     procedure AddUnitString(AUnitString: string);
+    procedure ParseExcludedClassPrefixesSwitch(var AParameter: Integer);
+    procedure AddExcludedClassPrefix(AClassPrefix: string);
     procedure ParseUnitFileSwitch(var AParameter: Integer);
     procedure ReadUnitsFile(const AUnitsFileName: string);
     procedure ParseExecutableParametersSwitch(var AParameter: Integer);
@@ -109,6 +112,7 @@ type
     function SourcePaths: TStrings;
     function Units: TStrings;
     function ExcludedUnits: TStrings;
+    function ExcludedClassPrefixes: TStrings;
     function UseApiDebug: Boolean;
     function IsComplete(var AReason: string): Boolean;
     function EmmaOutput: Boolean;
@@ -179,6 +183,11 @@ begin
   FExcludedUnitsStrLst.Sorted := True;
   FExcludedUnitsStrLst.Duplicates := dupIgnore;
 
+  FExcludedClassPrefixesStrLst := TStringList.Create;
+  FExcludedClassPrefixesStrLst.CaseSensitive := False;
+  FExcludedClassPrefixesStrLst.Sorted := True;
+  FExcludedClassPrefixesStrLst.Duplicates := dupIgnore;
+
   FDProjUnitsLst := TStringList.Create;
   FDProjUnitsLst.CaseSensitive := False;
   FDProjUnitsLst.Sorted := True;
@@ -205,6 +214,7 @@ destructor TCoverageConfiguration.Destroy;
 begin
   FLogManager := nil;
   FUnitsStrLst.Free;
+  FExcludedClassPrefixesStrLst.Free;
   FExcludedUnitsStrLst.Free;
   FExeParamsStrLst.Free;
   FSourcePathLst.Free;
@@ -264,6 +274,11 @@ end;
 function TCoverageConfiguration.ExcludedUnits : TStrings;
 begin
   Result := FExcludedUnitsStrLst;
+end;
+
+function TCoverageConfiguration.ExcludedClassPrefixes: TStrings;
+begin
+  Result := FExcludedClassPrefixesStrLst;
 end;
 
 function TCoverageConfiguration.SourcePaths: TStrings;
@@ -527,6 +542,8 @@ begin
 
   for CurrentUnit in FExcludedUnitsStrLst do
     VerboseOutput('Exclude from coverage tracking for: ' + CurrentUnit);
+
+  VerboseOutput('Exclude from coverage tracking classes with prefix: ' + FExcludedClassPrefixesStrLst.CommaText);
 end;
 
 function TCoverageConfiguration.ParseParameter(const AParameter: Integer): string;
@@ -569,6 +586,8 @@ begin
     ParseMapFileSwitch(AParameter)
   else if SwitchItem = I_CoverageConfiguration.cPARAMETER_UNIT then
     ParseUnitSwitch(AParameter)
+  else if SwitchItem = I_CoverageConfiguration.cPARAMETER_EXCLUDE_CLASS_PREFIX then
+    ParseExcludedClassPrefixesSwitch(AParameter)
   else if SwitchItem = I_CoverageConfiguration.cPARAMETER_UNIT_FILE then
     ParseUnitFileSwitch(AParameter)
   else if SwitchItem = I_CoverageConfiguration.cPARAMETER_EXECUTABLE_PARAMETER then
@@ -670,6 +689,31 @@ begin
   end;
 end;
 
+procedure TCoverageConfiguration.ParseExcludedClassPrefixesSwitch(var AParameter: Integer);
+var
+  Prefix: string;
+begin
+  Inc(AParameter);
+  try
+    Prefix := ParseParameter(AParameter);
+    while Prefix <> '' do
+    begin
+      AddExcludedClassPrefix(Prefix);
+
+      Inc(AParameter);
+      Prefix := ParseParameter(AParameter);
+    end;
+
+    if FExcludedClassPrefixesStrLst.Count = 0 then
+      raise EConfigurationException.Create('Expected at least one class prefix');
+
+    Dec(AParameter);
+  except
+    on EParameterIndexException do
+      raise EConfigurationException.Create('Expected at least one class prefix');
+  end;
+end;
+
 procedure TCoverageConfiguration.AddUnitString(AUnitString: string);
 begin
   if Length(AUnitString) > 0 then
@@ -682,6 +726,14 @@ begin
     end
     else
       FUnitsStrLst.add(AUnitString);
+  end;
+end;
+
+procedure TCoverageConfiguration.AddExcludedClassPrefix(AClassPrefix: string);
+begin
+  if Length(AClassPrefix) > 0 then
+  begin
+    FExcludedClassPrefixesStrLst.add(AClassPrefix);
   end;
 end;
 

--- a/Source/I_CoverageConfiguration.pas
+++ b/Source/I_CoverageConfiguration.pas
@@ -29,6 +29,7 @@ type
     function SourcePaths: TStrings;
     function Units: TStrings;
     function ExcludedUnits: TStrings;
+    function ExcludedClassPrefixes: TStrings;
     function DebugLogFile: string;
     function UseApiDebug: Boolean;
     function IsComplete(var AReason: string): Boolean;
@@ -55,6 +56,7 @@ const
   cPARAMETER_EXECUTABLE = '-e';
   cPARAMETER_MAP_FILE = '-m';
   cPARAMETER_UNIT = '-u';
+  cPARAMETER_EXCLUDE_CLASS_PREFIX = '-ecp';
   cPARAMETER_UNIT_FILE = '-uf';
   cPARAMETER_SOURCE_DIRECTORY = '-sd';
   cPARAMETER_OUTPUT_DIRECTORY = '-od';

--- a/Test/ClassInfoUnitTest.pas
+++ b/Test/ClassInfoUnitTest.pas
@@ -24,6 +24,8 @@ uses
 
   published
     procedure TestClassInfo;
+    procedure TestGetProcedureName;
+    procedure TestGetClassName;
  end;
 
 
@@ -34,6 +36,84 @@ var cinfo : TClassInfo;
 begin
   cinfo:= TClassInfo.Create('Module','MyClass');
   cinfo.ensureProcedure('TestProcedure');
+end;
+
+procedure TClassInfoUnitTest.TestGetProcedureName;
+begin
+  CheckEquals(
+    'Bar',
+    TModuleList.GetProcedureName('foo', 'foo.Bar'),
+    'foo.Bar should have Bar as procedure name'
+  );
+  CheckEquals(
+    'Baz',
+    TModuleList.GetProcedureName('foo', 'foo.Bar.Baz'),
+    'foo.Bar.Baz should have Baz as procedure name'
+  );
+  CheckEquals(
+    'Baz',
+    TModuleList.GetProcedureName('foo', 'foo.Bar.Baz$0'),
+    'foo.Bar.Baz$0 should have Baz as procedure name'
+  );
+  CheckEquals(
+    '',
+    TModuleList.GetProcedureName('foo', 'foo.Bar.Baz$ActRec.$0$Body'),
+    'foo.Bar.Baz$ActRec.$0$Body anonymous function should have no procedure name'
+  );
+  CheckEquals(
+    'Boo',
+    TModuleList.GetProcedureName('foo', 'foo.Bar.Baz.Boo'),
+    'foo.Bar.Baz.Boo should have Boo as procedure name'
+  );
+  CheckEquals(
+    'Boo',
+    TModuleList.GetProcedureName('foo', 'foo.Bar.Baz.Boo$0'),
+    'foo.Bar.Baz.Boo$0 should have Boo as procedure name'
+  );
+  CheckEquals(
+    '',
+    TModuleList.GetProcedureName('foo', 'foo.Bar.Baz.Boo$ActRec.$0$Body'),
+    'foo.Bar.Baz.Boo$ActRec.$0$Body anonymous function should have no procedure name'
+  );
+end;
+
+procedure TClassInfoUnitTest.TestGetClassName;
+begin
+  CheckEquals(
+    'Bar',
+    TModuleList.GetClassName('foo', 'foo.Bar'),
+    'foo.Bar should have Bar as class name'
+  );
+  CheckEquals(
+    'Bar',
+    TModuleList.GetClassName('foo', 'foo.Bar.Baz'),
+    'foo.Bar.Baz should have Bar as class name'
+  );
+  CheckEquals(
+    'Bar',
+    TModuleList.GetClassName('foo', 'foo.Bar.Baz$0'),
+    'foo.Bar.Baz$0 should have Bar as class name'
+  );
+  CheckEquals(
+    'Bar.Baz$ActRec',
+    TModuleList.GetClassName('foo', 'foo.Bar.Baz$ActRec.$0$Body'),
+    'foo.Bar.Baz$ActRec.$0$Body anonymous function should have Bar as class name'
+  );
+  CheckEquals(
+    'Bar.Baz',
+    TModuleList.GetClassName('foo', 'foo.Bar.Baz.Boo'),
+    'foo.Bar.Baz.Boo should have Bar.Baz as class name'
+  );
+  CheckEquals(
+    'Bar.Baz',
+    TModuleList.GetClassName('foo', 'foo.Bar.Baz.Boo$0$Body'),
+    'foo.Bar.Baz.Boo$0$Body should have Bar.Baz as class name'
+  );
+  CheckEquals(
+    'Bar.Baz',
+    TModuleList.GetClassName('foo', 'foo.Bar.Baz.$0$Body'),
+    'foo.Bar.Baz.$0$Body anonymous function should have Bar as class name'
+  );
 end;
 
 //==============================================================================


### PR DESCRIPTION
These changes add the ability to exclude classes from code coverage from classes with the given prefix. This is useful if your main and test code live in the same unit.

NB: Sub procedures are not excluded due to the way they are compiled.