### PR TITLE
Fix truncated x64 base address breaking breakpoint activation

### DIFF
--- a/Source/Debugger.pas
+++ b/Source/Debugger.pas
@@ -922,7 +922,7 @@ begin
   FDebugProcess := TDebugProcess.Create(
     ADebugEvent.dwProcessId,
     ADebugEvent.CreateProcessInfo.hProcess,
-    DWORD(ADebugEvent.CreateProcessInfo.lpBaseOfImage),
+    HMODULE(ADebugEvent.CreateProcessInfo.lpBaseOfImage),
     ProcessName,
     Size,
     FMapScanner,


### PR DESCRIPTION
TDebugger.HandleCreateProcess cast the debuggee's lpBaseOfImage through DWORD before storing it as the process module base. On Win64 this truncates the 64-bit load address to its low 32 bits, which is always wrong since 64-bit images are based well above the 4GB boundary. Every breakpoint address computed from that bogus base falls outside any mapped region of the target process, so ReadProcessMemory/WriteProcessMemory fail with ERROR_PARTIAL_COPY (299) for every single breakpoint and no coverage is collected.

Cast to HMODULE instead, matching the existing (correct) handling of lpBaseOfDll in HandleLoadDLL.